### PR TITLE
Path sum iii

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
-# path-sum-III
+# Path Sum III
+
 Given the root of a binary tree and an integer targetSum, return the number of paths where the sum of the values along the path equals targetSum.
+
+The path does not need to start or end at the root or a leaf, but it must go downwards (i.e., traveling only from parent nodes to child nodes).
+
+ 
+
+Example 1:
+
+
+Input: root = [10,5,-3,3,2,null,11,3,-2,null,1], targetSum = 8
+Output: 3
+Explanation: The paths that sum to 8 are shown.
+Example 2:
+
+Input: root = [5,4,8,11,null,13,4,7,2,null,null,5,1], targetSum = 22
+Output: 3
+ 
+
+Constraints:
+
+The number of nodes in the tree is in the range [0, 1000].
+-109 <= Node.val <= 109
+-1000 <= targetSum <= 1000

--- a/path-sum-III.js
+++ b/path-sum-III.js
@@ -23,6 +23,10 @@
         if(map[cumulativeSum - targetSum]){
             totalPath += map[cumulativeSum - targetSum]
         }
+        map[cumulativeSum] = ++map[cumulativeSum] || 1
+        findPathSum(node.left, cumulativeSum)
+        findPathSum(node.right, cumulativeSum)
+        map[cumulativeSum] = --map[cumulativeSum]
 
         
     }

--- a/path-sum-III.js
+++ b/path-sum-III.js
@@ -17,5 +17,13 @@
     let totalPath = 0
     findPathSum(root, 0)
     return totalPath
-    
+    function findPathSum(node, sum){
+        if(!node) return null
+        let cumulativeSum = node.val + sum
+        if(map[cumulativeSum - targetSum]){
+            totalPath += map[cumulativeSum - targetSum]
+        }
+
+        
+    }
 };

--- a/path-sum-III.js
+++ b/path-sum-III.js
@@ -15,5 +15,7 @@
 
     const map = {0:1}
     let totalPath = 0
+    findPathSum(root, 0)
+    return totalPath
     
 };

--- a/path-sum-III.js
+++ b/path-sum-III.js
@@ -13,5 +13,7 @@
  */
  var pathSum = function(root, targetSum) {
 
-  
+    const map = {0:1}
+    let totalPath = 0
+    
 };

--- a/path-sum-III.js
+++ b/path-sum-III.js
@@ -27,7 +27,10 @@
         findPathSum(node.left, cumulativeSum)
         findPathSum(node.right, cumulativeSum)
         map[cumulativeSum] = --map[cumulativeSum]
-
+        if(!map[cumulativeSum]){
+            //      to free the memory        
+                delete map[cumulativeSum]
+            }
         
     }
 };

--- a/path-sum-III.js
+++ b/path-sum-III.js
@@ -1,0 +1,17 @@
+/**
+ * Definition for a binary tree node.
+ * function TreeNode(val, left, right) {
+ *     this.val = (val===undefined ? 0 : val)
+ *     this.left = (left===undefined ? null : left)
+ *     this.right = (right===undefined ? null : right)
+ * }
+ */
+/**
+ * @param {TreeNode} root
+ * @param {number} targetSum
+ * @return {number}
+ */
+ var pathSum = function(root, targetSum) {
+
+  
+};


### PR DESCRIPTION
Given the root of a binary tree and an integer `targetSum`, return the number of paths where the sum of the values along the path equals `targetSum`.

The path does not need to start or end at the root or a leaf, but it must go downwards (i.e., traveling only from parent nodes to child nodes).